### PR TITLE
Fluxo da Footprint funcional

### DIFF
--- a/Cerne/Components/AlertView.swift
+++ b/Cerne/Components/AlertView.swift
@@ -8,11 +8,51 @@
 import SwiftUI
 
 struct AlertView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+    let title: String
+    let message: String
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
 
-#Preview {
-    AlertView()
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 10){
+                Text(title)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 22)
+                
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 22)
+            }
+            
+            HStack(spacing: 16) {
+                Button("Cancelar") {
+                    onCancel()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 13)
+                .background(.thinMaterial)
+                .foregroundStyle(.primitive2)
+                .font(.callout)
+                .clipShape(RoundedRectangle(cornerRadius: 100))
+
+                Button("Continuar") {
+                    onConfirm()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 13)
+                .background(.primitive2)
+                .foregroundStyle(.white)
+                .fontWeight(.medium)
+                .font(.body)
+                .clipShape(RoundedRectangle(cornerRadius: 100))
+                
+            }
+            .padding(14)
+        }
+        .glassEffect(in: .rect(cornerRadius: 26))
+    }
 }

--- a/Cerne/Components/RegisterConcluded.swift
+++ b/Cerne/Components/RegisterConcluded.swift
@@ -1,0 +1,33 @@
+//
+//  RegisterConcluded.swift
+//  Cerne
+//
+//  Created by Richard Fagundes Rodrigues on 26/09/25.
+//
+
+import SwiftUI
+
+struct RegisterConcluded: View {
+    let title: String
+    let message: String
+    
+    var body: some View {
+        VStack(alignment: .center, spacing: 10) {
+            Text(title)
+                .font(.headline)
+                .fontWeight(.semibold)
+            
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, 24)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity)
+        .glassEffect(in: .rect(cornerRadius: 26))
+    }
+}
+
+#Preview {
+    RegisterConcluded(title: "Registro", message: "Pegada de carbono")
+}

--- a/Cerne/Features/Footprint/FootprintViewModel.swift
+++ b/Cerne/Features/Footprint/FootprintViewModel.swift
@@ -15,6 +15,7 @@ class FootprintViewModel: FootprintViewModelProtocol {
     var currentPage: Int = 1
     var selections: [CarbonEmittersEnum: String] = [:]
     var showDiscardAlert: Bool = false
+    var showConludedAlert: Bool = false
     
     var totalQuestionPages: Int {
         let totalItems = CarbonEmittersEnum.allCases.count
@@ -69,16 +70,14 @@ class FootprintViewModel: FootprintViewModelProtocol {
     
     func saveFootprint() async {
         if isAbleToSave {
-            let (totalCarbonFootprint, userResponses) = calculateCarbonEmissions()
-            
-            print("Pegada de carbono total: \(totalCarbonFootprint) kg de CO² por ano.")
+            let (_, userResponses) = calculateCarbonEmissions()
             
             do {
                 let currentUser = try await userService.fetchOrCreateCurrentUser(name: nil, height: nil)
                 try footprintService.createOrUpdateFootprint(for: currentUser, with: userResponses)
-                
-                print("Pegada de carbono salva com sucesso!")
 
+                showConludedAlert = true
+                
             } catch {
                 print("Erro ao salvar a pegada de carbono: \(error.localizedDescription)")
             }

--- a/Cerne/Features/Today/TodayView.swift
+++ b/Cerne/Features/Today/TodayView.swift
@@ -142,12 +142,14 @@ struct TodayView: View {
             .navigationDestination(for: Route.self) { route in
                 switch route {
                 case .footprint:
-                    FootprintView(viewModel: FootprintViewModel(
+                    FootprintView(
+                        viewModel: FootprintViewModel(
                         footprintService: FootprintService(),
                         userService: UserService()
-                    )
+                        )
                     )
                     .toolbar(.hidden, for: .tabBar)
+                    .navigationBarBackButtonHidden(true)
                     
                 case .registerTree:
                     PhotoView(


### PR DESCRIPTION
Agora é possível acessar o cálculo de pegada e ir até o final do fluxo com o retorno automático pra tela inicial. 

Ainda falta terminar de ajustar a UI e habilitar a possibilidade de editar o cálculo ao clicar no componente de meta mensal novamente.