### PR TITLE
Melhorada a detecao de plano para posicionamento dos pontos e objeto 3D

### DIFF
--- a/Cerne/Features/Diameter/DiameterView.swift
+++ b/Cerne/Features/Diameter/DiameterView.swift
@@ -32,6 +32,22 @@ struct DiameterView: View {
                         .fill(Color.white)
                         .frame(width: 8, height: 8)
                     
+                    if let result = viewModel.result, result > 0 {
+                    } else {
+                        GeometryReader { geometry in
+                            let center = CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
+                            let measurementAnchors = viewModel.arService.arView.scene.anchors.filter { $0.name == "measurementPointAnchor" }
+                            if measurementAnchors.count == 1, let firstPointAnchor = measurementAnchors.first,
+                               let firstPoint = viewModel.arService.arView.project(firstPointAnchor.position) {
+                                Path { path in
+                                    path.move(to: firstPoint)
+                                    path.addLine(to: center)
+                                }
+                                .stroke(Color.white, lineWidth: 2)
+                            }
+                        }
+                    }
+                    
                     VStack (spacing: 15) {
                         Spacer()
                         
@@ -46,6 +62,17 @@ struct DiameterView: View {
                                 .clipShape(Capsule())
                                 .transition(.opacity.animation(.easeInOut))
                             
+                        }
+                        
+                        if let result = viewModel.result, result > 0 {
+                            Text(String(format: "%.2f m", result))
+                                .font(.body)
+                                .fontWeight(.medium)
+                                .padding(.vertical, 12)
+                                .padding(.horizontal, 16)
+                                .background(.ultraThinMaterial)
+                                .clipShape(Capsule())
+                                .transition(.opacity.animation(.easeInOut))
                         }
                         
                         if viewModel.result == nil || viewModel.result == 0 {
@@ -106,7 +133,7 @@ struct DiameterView: View {
             }
         }
         .navigationBarBackButtonHidden(true)
-        .navigationDestination(isPresented: $viewModel.shouldNavigate) {
+        .navigationDestination(isPresented: Binding(get: { viewModel.shouldNavigate }, set: { viewModel.shouldNavigate = $0 })) {
             DistanceView(
                 viewModel: DistanceViewModel(
                     userDefaultService: UserDefaultService(),
@@ -119,3 +146,4 @@ struct DiameterView: View {
         }
     }
 }
+


### PR DESCRIPTION
Ajustes na detecção:
- Pontos de diâmetro agora tem uma cor vermelha opaca para melhor visibilidade.
- É possível ver uma label com a medida total do diâmetro após a conclusão da medição.
- O objeto 3D para verificar a distância da árvore e os pontos do diâmetro agora tem maior facilidade para detectar o espaço plano.
- Para o objeto 3D, garanti que o plano fosse horizontal para evitar que ele mudasse seu eixo ou ficasse flutuando no ar em distâncias estranhas.